### PR TITLE
build: Use ccomp_type to determine C compiler

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -5,7 +5,7 @@ let dispatch = function
   | After_rules ->
     let env = BaseEnvLight.load () in
     let system = BaseEnvLight.var_get "system" env in
-    let cc = BaseEnvLight.var_get "ccomp_type" env in
+    let cc = BaseEnvLight.var_get "bytecomp_c_compiler" env in
     let is_darwin = String.is_prefix "macos" system in
     let arch_sixtyfour = BaseEnvLight.var_get "arch_sixtyfour" env = "true" in
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -5,10 +5,11 @@ let dispatch = function
   | After_rules ->
     let env = BaseEnvLight.load () in
     let system = BaseEnvLight.var_get "system" env in
+    let cc = BaseEnvLight.var_get "ccomp_type" env in
     let is_darwin = String.is_prefix "macos" system in
     let arch_sixtyfour = BaseEnvLight.var_get "arch_sixtyfour" env = "true" in
 
-    let cpp = "gcc -E -xc -undef -w" in
+    let cpp = cc ^ " -E -xc -undef -w" in
     let cpp = if arch_sixtyfour then cpp ^ " -DARCH_SIXTYFOUR" else cpp in
 
     let cpp = S [A "-pp"; P cpp] in


### PR DESCRIPTION
This library did not build properly on FreeBSD because of the hard-coded C compiler in `myocamlbuild.ml`. The file now checks `ccomp_type` to determine the C compiler to use, which should make the library more portable.

Tested on FreeBSD 10.0.

Closes #6