### PR TITLE
Fix link to online documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage
 The API (`.mli`-files) in the `bin_prot` library directory (`lib`)
 is fully documented, and HTML-documentation can be built from it on
 installation.  The documentation for the latest release can also be found
-[online](http://mmottl.bitbucket.org/projects/bin_prot/api/).
+[online](https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/Bin_prot/index.html).
 
 Module `Common` defines some globally used types, functions, exceptions,
 and values.  `Nat0` implements natural numbers including zero.


### PR DESCRIPTION
This PR changes the link in the `README.md` file to:

    https://ocaml.janestreet.com/ocaml-core/latest/doc/bin_prot/Bin_prot/index.html