### PR TITLE
Add `:standard` to the stub flags

### DIFF
--- a/xen/cflags.sh
+++ b/xen/cflags.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e -o pipefail
 flags="$(pkg-config --static mirage-xen --cflags)" || flags=""
-echo "($flags)"
+echo "(:standard $flags)"


### PR DESCRIPTION
While running the CI tests for a PR in Yojson, I realized that `bin_prot` [doesn't build on `opensuse-15.5-5.2_opam-2.1`](https://ocaml.ci.dev/github/ocaml-community/yojson/commit/1df1df5483a8cc25247d53215de8cf7d686f8824/variant/opensuse-15.5-5.2_opam-2.1) with the following error:

```
# /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: xen/blit_stubs.o: warning: relocation against `caml_leave_blocking_section' in read-only section `.text'
# /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: xen/blit_stubs.o: relocation R_X86_64_PC32 against symbol `memcpy@@GLIBC_2.14' can not be used when making a shared object; recompile with -fPIC
# /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: final link failed: bad value
# collect2: error: ld returned 1 exit status
```

This is most likely due to `mirage-xen` not existing thus flags being set to `()`

```
Package mirage-xen was not found in the pkg-config search path.
Perhaps you should add the directory containing `mirage-xen.pc'
to the PKG_CONFIG_PATH environment variable
No package 'mirage-xen' found
File "xen/dune", line 8, characters 0-215:
 8 | (library
 9 |  (foreign_stubs
10 |   (language c)
11 |   (flags
12 |    (:include cflags.sexp)))
13 |  (name bin_prot_xen)
14 |  (public_name bin_prot.xen)
15 |  (optional)
16 |  (virtual_deps mirage-xen-ocaml)
17 |  (libraries)
18 |  (preprocess no_preprocessing))
```

This PR adds `:standard` flags to the build in any case.