### PR TITLE
Remove hardcoded path to bash in shebang

### DIFF
--- a/xen/cflags.sh
+++ b/xen/cflags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 flags="$(pkg-config --static mirage-xen --cflags)" || flags=""
 echo "($flags)"


### PR DESCRIPTION
Such hardcoded path prevent to build and `opam install` bin_prot on platforms where bash is not at the expected location, such as NixOS. `/usr/bin/env bash` is the most portable shebang for UNIX-like systems.